### PR TITLE
implement a client class for an authenticated api

### DIFF
--- a/webapp/backend/src/routes/topologyRoutes.ts
+++ b/webapp/backend/src/routes/topologyRoutes.ts
@@ -122,12 +122,29 @@ router.delete('/:id', authenticateToken, async (req: AuthenticatedRequest, res) 
 
     const { id } = req.params;
 
+    // validate id
+    const topologyId = parseInt(id);
+    if (isNaN(topologyId)) {
+        res.status(400).json({ message: 'Invalid topology ID format' });
+        return;
+    }
+
     try {
-        await prisma.topology.delete({
-            where: { id: parseInt(id) },
+        // check if the topology exists
+        const topology = await prisma.topology.findUnique({
+            where: { id: topologyId }
         });
 
-        res.status(204).send();
+        if (!topology) {
+            res.status(404).json({ message: 'Topology not found' });
+            return;
+        }
+
+        await prisma.topology.delete({
+            where: { id: topologyId },
+        });
+
+        res.status(200).json({ topologyId });
     } catch (error) {
         res.status(500).json({ message: 'Error deleting topology', error });
     }

--- a/webapp/frontend/package-lock.json
+++ b/webapp/frontend/package-lock.json
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
       "dependencies": {
         "levn": "^0.4.1"
@@ -1990,9 +1990,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",

--- a/webapp/frontend/src/components/CreateTopology.tsx
+++ b/webapp/frontend/src/components/CreateTopology.tsx
@@ -1,36 +1,20 @@
 import { PlusCircle } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import { useNavigate } from "react-router-dom";
-import { Topology } from "../types/types";
 
 const CreateTopology = () => {
-    const { token } = useAuth();
+    const { token, authenticatedApiClient } = useAuth();
     const navigateTo = useNavigate();
 
     const handleCreateTopology = async () => {
         if (!token) {
             return;
         }
-
         try {
-            const response = await fetch('/api/topology/', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': `Bearer ${token}`,
-                },
-                body: JSON.stringify({
-                    name: `Topology_${Date.now()}`,
-                }),
+            const response = await authenticatedApiClient.createTopology({
+                name: `Topology_${Date.now()}`
             });
-
-            if (!response.ok) {
-                throw new Error('Failed to create topology');
-            }
-
-            const data: Topology = await response.json();
-
-            navigateTo(`/topology/${data.id}`);
+            navigateTo(`/topology/${response.data!.id}`);
         } catch (error) {
             console.error('Error creating topology:', error);
         }

--- a/webapp/frontend/src/lib/authenticatedApi.ts
+++ b/webapp/frontend/src/lib/authenticatedApi.ts
@@ -1,0 +1,105 @@
+import type { ApiResponse, Topology } from "../types/types";
+import { ReactFlowJsonObject } from "@xyflow/react";
+
+type ApiConfig = {
+    baseUrl: string;
+    getToken: () => string | null;
+};
+type ApiError = {
+    message: string;
+    status?: number;
+};
+
+export class ApiClient {
+    private readonly baseUrl: string;
+    private readonly getToken: () => string | null;
+
+    constructor(config: ApiConfig) {
+        this.baseUrl = config.baseUrl;
+        this.getToken = config.getToken;
+    }
+
+    private async fetch<T>(
+        endpoint: string,
+        options?: RequestInit
+    ): Promise<ApiResponse<T>> {
+        const token = this.getToken();
+
+        const headers = {
+            'Content-Type': 'application/json',
+            ...(token && { Authorization: `Bearer ${token}` }),
+            ...options?.headers,
+        }
+
+        const response = await fetch(`${this.baseUrl}${endpoint}`, {
+            ...options,
+            headers
+        });
+
+        if (!response.ok) {
+            const error: ApiError = {
+                message: `Error ${response.status}: ${response.statusText}`,
+                status: response.status,
+            };
+
+            if (response.status === 401) {
+                // maybe trigger a logout or token refresh here
+                error.message = 'Your session has expired. Please log in again.';
+            }
+
+            throw error;
+        }
+
+        // check if response has JSON
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+            const jsonData = await response.json();
+            return {
+                success: true,
+                message: jsonData.message,
+                data: jsonData,
+            };
+        }
+
+        // handle non JSON responses
+        return {
+            success: true,
+            message: 'Operation completed successfully',
+            data: undefined,
+        };
+    }
+
+    // API Methods go here
+    async createTopology(data: Partial<Topology>) {
+        return this.fetch<Topology>('/topology/', {
+            method: 'POST',
+            body: JSON.stringify(data),
+        })
+    }
+
+    async getAllTopologies() {
+        return this.fetch<Topology[]>('/topology/');
+    }
+
+    async getTopology(id: number) {
+        return this.fetch<Topology>(`/topology/${id}`);
+    }
+
+    async updateTopology(id: number, data: {
+        react_flow_state: ReactFlowJsonObject
+        thumbnail: string
+    }) {
+        return this.fetch<Topology>(`/topology/${id}`, {
+            method: 'PUT',
+            body: JSON.stringify(data)
+        });
+    }
+
+    async deleteTopology(id: number) {
+        // The topology endpoint doesn't return anything on delete - may need to change this
+        // Possibly return the id of the record deleted?
+        return this.fetch<{ topologyId: number }>(`/topology/${id}`, {
+            method: 'DELETE'
+        });
+    }
+}


### PR DESCRIPTION
Added a class `ApiClient` for ease of use when making authenticated calls throughout the application.

Implemented this client in the following areas:
- creating topologies
- deleting topologies
- updating topologies
- getting all topologies

Other changes:
- Modified delete topology backend endpoint to return the deleted topology id