### PR TITLE
Remove redundant dependency from useEffect in ConnectionsTable component

### DIFF
--- a/frontend/src/components/table/ConnectionsTable.tsx
+++ b/frontend/src/components/table/ConnectionsTable.tsx
@@ -147,7 +147,7 @@ function ConnectionsTable({ interconnectDevices, labDevices }: ConnectionsTableP
                 storeNewConnections(newConnections);
             }
         }
-    }, [labDevices, labDevicesLoaded, seenLabDevices, connections]);
+    }, [labDevices, labDevicesLoaded, seenLabDevices]);
 
     // handle deletion of connections when a lab device is deleted or ports are removed from a lab device
     useEffect(() => {


### PR DESCRIPTION
Removed connections from useEffect triggered by adding new lab devices or ports. This would cause the connections to be tripled.